### PR TITLE
docs (issue template): Added issues templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'FIX: <description>'
+labels: bug
+assignees: ''
+
+---
+
+FIX: <quick description>
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom-issue.md
+++ b/.github/ISSUE_TEMPLATE/custom-issue.md
@@ -1,0 +1,12 @@
+---
+name: Custom issue
+about: Describe this issue here.
+title: "<type>: <descritpion>"
+labels: ''
+assignees: ''
+
+---
+
+<type>: <quick descprition>
+
+** Describe your issue **

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'feat: <description>'
+labels: enhancement
+assignees: ''
+
+---
+
+FEAT: <quick description>
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This pull request introduces new issue templates to standardize the reporting and feature request process. The changes include adding templates for bug reports, custom issues, and feature requests.

New issue templates:

* [`.github/ISSUE_TEMPLATE/bug_report.md`](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5R1-R40): Added a template for bug reports to help users provide detailed and structured information about bugs.
* [`.github/ISSUE_TEMPLATE/custom-issue.md`](diffhunk://#diff-21e77efd2c8a158cba5eae5465c3647ab25e28f1371cdb0fa8c7613139d49e3fR1-R12): Added a template for custom issues to allow users to describe various types of issues in a flexible format.
* [`.github/ISSUE_TEMPLATE/feature_request.md`](diffhunk://#diff-148870715557a13127284f8aeaa28002ed6b034268af13c5d030ab59fd078220R1-R22): Added a template for feature requests to guide users in suggesting new features and improvements.