### PR TITLE
fix(ci): remove make clean command of the check executables

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,6 @@ jobs:
               return_value=0
 
               make
-              make clean
 
               for file in "${files[@]}"
               do


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/check.yml` file. The change removes the `make clean` command from the `jobs:` section.

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L30): Removed the `make clean` command from the `jobs:` section.