### PR TITLE
FEAT: Handle display output

### DIFF
--- a/src/analyzer/main.py
+++ b/src/analyzer/main.py
@@ -1,10 +1,25 @@
 #!/usr/bin/env python3
 
 import sys
+import math
 
 from src.commandParsing.commandParsing import *
 from src.analyzer.multi_perceptron import multiNeuron
 from src.datasetParsing.datasetParsing import *
+
+def display_result(outputs : list[int]) -> None:
+    if (len(outputs) != 6):
+        exit(0)
+    max = -math.inf
+    max_index = 0
+    for index, value in enumerate(outputs):
+        if max < value:
+            max = value
+            max_index = index
+    for i in mapOutcomeList:
+        if mapOutcomeList[i][max_index] == 1:
+            print(i)
+
 
 def main():
     parser : CommandParsing = CommandParsing()
@@ -17,7 +32,9 @@ def main():
             board : list[int] = [y for x in board_state.chessPlate for y in x]
             outcome : list[int] = [i for i in board_state.outcome]
             input = board + outcome + [board_state.turn, board_state.castlingrights, board_state.targetsquare, board_state.halfmoveclock, board_state.fullmove]
-            mlp.predict(input)
+            outputs : list[int] = mlp.predict(input)
+            display_result(outputs)
+
     else:
         print("train")
 

--- a/src/analyzer/multi_perceptron.py
+++ b/src/analyzer/multi_perceptron.py
@@ -12,14 +12,14 @@ class multiNeuron:
         #TODO: @Kiki implement the creation of the mlp thanks to a loading file
         pass
 
-    def predict(self, input : chessState) -> int:
+    def predict(self, input : chessState) -> list[int]:
         last_inputs : list[int] = []
         for layer in self.neural_network:
             last_inputs = []
             for neuron in layer:
                 last_inputs.append(neuron.predict(input))
             input = last_inputs
-        return input[0]
+        return input
 
     def train(self, inputs : list[list[int]], targets : list[int], max_iteration=10000) -> None:
         for iteration in range(max_iteration):


### PR DESCRIPTION
This pull request includes changes to the `src/analyzer` module to improve the handling and display of prediction results from the multi-layer perceptron (MLP). The most important changes include adding a new function to display results, modifying the `predict` method to return a list of integers, and updating the main function to utilize the new display function.

Enhancements to result handling:

* [`src/analyzer/main.py`](diffhunk://#diff-688777725d1df606ac0fafb643bdb2a46b59ce4b96d465ec1bdbd267c812deacR4-R23): Added the `display_result` function to print the result based on the highest value in the MLP output.
* [`src/analyzer/main.py`](diffhunk://#diff-688777725d1df606ac0fafb643bdb2a46b59ce4b96d465ec1bdbd267c812deacL20-R37): Updated the `main` function to call `display_result` with the output from `mlp.predict`.

Modifications to MLP prediction:

* [`src/analyzer/multi_perceptron.py`](diffhunk://#diff-976ab813134e8386aee668e9b3d95bcf5454249ea8e215f9e68e8e1f2b2d4015L15-R22): Changed the `predict` method to return a list of integers instead of a single integer, allowing for more detailed output handling.