### PR TITLE
refactor: rename variables in Generator and remove some variable of t…

### DIFF
--- a/src/generator/Generator.py
+++ b/src/generator/Generator.py
@@ -31,10 +31,7 @@ class Generator :
 
     def save_network(self, filepath : str = "neural_network_1.nn") -> None:
         network_data = {
-            "nb_input_values": self.nb_input_values,
-            "nb_layouts": self.nb_layouts,
             "learning_rate": self.learning_rate,
-            "nb_output_neurons": self.nb_output_neurons,
             "layouts": [
                         [
                             json.loads(perceptron.save_state()) for perceptron in layout

--- a/src/generator/ParseConfig.py
+++ b/src/generator/ParseConfig.py
@@ -2,7 +2,7 @@ class ParseConfFile:
     def __init__(self, config_file: str):
         self.config_file : str = config_file
         self.nb_inputs : int = 0
-        self.nb_layouts : int = 0
+        self.nb_layers : int = 0
         self.nb_output_neurons : int = 0
         self.learning_rate : float = 0.0
         self.neurons_per_layer : list[int] = []
@@ -21,17 +21,17 @@ class ParseConfFile:
 
                     if key == "nb_inputs":
                         self.nb_inputs = int(value)
-                    elif key == "nb_layouts":
-                        self.nb_layouts = int(value)
-                        self.neurons_per_layer = [0] * self.nb_layouts
-                        self.activation_functions = [""] * self.nb_layouts
+                    elif key == "nb_layers":
+                        self.nb_layers = int(value)
+                        self.neurons_per_layer = [0] * self.nb_layers
+                        self.activation_functions = [""] * self.nb_layers
                     elif key == "learning_rate" :
                         self.learning_rate = float(value)
                     elif key == "nb_output_neurons":
                         self.nb_output_neurons = int(value)
                     elif key.startswith("nb_neuron_layout_"):
                         layout_index = int(key.split("_")[-1]) - 1
-                        if layout_index < self.nb_layouts:
+                        if layout_index < self.nb_layers:
                             values = value.split(",")
                             neuron_count = int(values[0].strip())
                             activation_function = values[1].strip() if len(values) > 1 else None
@@ -48,7 +48,7 @@ class ParseConfFile:
     def get_config(self):
         return {
             "nb_inputs": self.nb_inputs,
-            "nb_layouts": self.nb_layouts,
+            "nb_layers": self.nb_layers,
             "nb_output_neurons": self.nb_output_neurons,
             "learning_rate": self.learning_rate,
             "neurons_per_layer": self.neurons_per_layer,


### PR DESCRIPTION
This pull request includes changes to the `src/generator` package, focusing on renaming variables and updating the configuration parsing logic. The most important changes include renaming `nb_layouts` to `nb_layers` and updating related logic in the `ParseConfig` class and `Generator` class.

Variable renaming:

* [`src/generator/ParseConfig.py`](diffhunk://#diff-6f7f2825315548ff3b7ba15fbd8a0e39d72b759cd9aa86c799f64d5335419b3bL5-R5): Renamed `nb_layouts` to `nb_layers` in the `ParseConfFile` class and updated all related logic in the `parse` method. [[1]](diffhunk://#diff-6f7f2825315548ff3b7ba15fbd8a0e39d72b759cd9aa86c799f64d5335419b3bL5-R5) [[2]](diffhunk://#diff-6f7f2825315548ff3b7ba15fbd8a0e39d72b759cd9aa86c799f64d5335419b3bL24-R34) [[3]](diffhunk://#diff-6f7f2825315548ff3b7ba15fbd8a0e39d72b759cd9aa86c799f64d5335419b3bL51-R51)

Configuration parsing logic:

* [`src/generator/Generator.py`](diffhunk://#diff-c84eb8fd02a0995d89401aab8b86392c9f661d502c6d694423d4de380a8c1addL34-L37): Removed references to `nb_layouts` and `nb_input_values` in the `save_network` method to align with the updated configuration logic.