### PR TITLE
FIX: Change type of inputs

### DIFF
--- a/src/analyzer/main.py
+++ b/src/analyzer/main.py
@@ -32,7 +32,7 @@ def main():
         chessParsing = parseFile(command[2])
         for board_state in chessParsing:
             board : list[int] = [y for x in board_state.chessPlate for y in x]
-            input = board + [board_state.turn, board_state.castlingrights, board_state.targetsquare, board_state.halfmoveclock, board_state.fullmove]
+            input = board + [board_state.turn, board_state.halfmoveclock, board_state.fullmove]
             outputs : list[int] = mlp.predict(input)
             display_result(outputs)
 
@@ -44,7 +44,7 @@ def main():
         for board_state in chessParsing:
             board : list[int] = [y for x in board_state.chessPlate for y in x]
             targets.append(board_state.outcome)
-            input = board + [board_state.turn, board_state.castlingrights, board_state.targetsquare, board_state.halfmoveclock, board_state.fullmove]
+            input = board + [board_state.turn, board_state.halfmoveclock, board_state.fullmove]
             inputs.append(input)
         mlp.train(inputs, targets, PERIOD)
         # mlp.save(command[1]) TODO : save the MLP in the file
@@ -57,7 +57,7 @@ def main():
         for board_state in chessParsing:
             board : list[int] = [y for x in board_state.chessPlate for y in x]
             targets.append(board_state.outcome)
-            input = board + [board_state.turn, board_state.castlingrights, board_state.targetsquare, board_state.halfmoveclock, board_state.fullmove]
+            input = board + [board_state.turn, board_state.halfmoveclock, board_state.fullmove]
             inputs.append(input)
         mlp.train(inputs, targets, PERIOD)
         # mlp.save(command[1]) TODO : save the MLP in the file

--- a/src/datasetParsing/datasetParsing.py
+++ b/src/datasetParsing/datasetParsing.py
@@ -73,8 +73,8 @@ def parseDataLine(state : chessState, line : str):
     state.turn = turnToInt(parsed[1])
     state.castlingrights = parsed[2]
     state.targetsquare = parsed[3]
-    state.halfmoveclock = parsed[4]
-    state.fullmove = parsed[5]
+    state.halfmoveclock = int(parsed[4])
+    state.fullmove = int(parsed[5])
     if (len(parsed) > 6):
         tmp = parsed[6]
         if (len(parsed) > 7):

--- a/src/generator/Generator.py
+++ b/src/generator/Generator.py
@@ -17,7 +17,6 @@ class Generator :
         nb_last_input : int = nb_inputs
         layer_iterator : int = 0
 
-        print(layers_nb_neurons)
         for nb_neurons_in_layer in layers_nb_neurons:
             self.neural_network.append([PerceptronLite(nb_last_input, layers_activation_functions[layer_iterator])])
             for _ in range(nb_neurons_in_layer - 1):


### PR DESCRIPTION
This pull request includes several changes to the `src/analyzer/main.py`, `src/datasetParsing/datasetParsing.py`, and `src/generator/Generator.py` files. The most important changes involve simplifying the input data for the neural network and ensuring proper data types for parsed values.

### Simplification of input data:

* [`src/analyzer/main.py`](diffhunk://#diff-688777725d1df606ac0fafb643bdb2a46b59ce4b96d465ec1bdbd267c812deacL35-R35): Removed `castlingrights` and `targetsquare` from the input data used for predictions and training in the `main` function. [[1]](diffhunk://#diff-688777725d1df606ac0fafb643bdb2a46b59ce4b96d465ec1bdbd267c812deacL35-R35) [[2]](diffhunk://#diff-688777725d1df606ac0fafb643bdb2a46b59ce4b96d465ec1bdbd267c812deacL47-R47) [[3]](diffhunk://#diff-688777725d1df606ac0fafb643bdb2a46b59ce4b96d465ec1bdbd267c812deacL60-R60)

### Data type corrections:

* [`src/datasetParsing/datasetParsing.py`](diffhunk://#diff-f1ebc2d968b2d5b039a099f57cc5f00babb5046e9fd264b9a94302a9b0ee5c78L76-R77): Corrected the data types of `halfmoveclock` and `fullmove` to integers in the `parseDataLine` function.

### Code cleanup:

* [`src/generator/Generator.py`](diffhunk://#diff-c84eb8fd02a0995d89401aab8b86392c9f661d502c6d694423d4de380a8c1addL20): Removed an unnecessary print statement from the `init_network` method.